### PR TITLE
feat: support for custom vars and keyword color

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,10 +87,14 @@ export function presetTheme<T extends Record<string, any>>(options: PresetThemeO
           else if (typeof val === 'string') {
             const name = [prefix, ...themeKeys].join('-')
             if (themeKeys[0] === 'colors') {
-              const cssColor = parseCssColor(val)
-              if (cssColor) {
+              const cssColor = parseCssColor(val) || val
+              if (typeof cssColor !== 'string') {
                 setThemeValue(name, 0, true)
                 curTheme[key] = wrapCSSFunction(cssColor.type, wrapVar(name), cssColor?.alpha)
+              }
+              else {
+                setThemeValue(name, 0, true)
+                curTheme[key] = wrapVar(name)
               }
             }
             else {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -262,4 +262,43 @@ describe('theme', () => {
       .pt-7{padding-top:1.75rem;}"
     `)
   })
+
+  test('color-keyword-and-custom-vars', async () => {
+    const uno = createGenerator({
+      theme: {
+        colors: {
+          primary: '#123456',
+          colorKey: 'red',
+          customVar: 'var(--fd-color-light)',
+        },
+      },
+      presets: [
+        presetUno(),
+        presetTheme<Theme>({
+          theme: {
+            dark: {
+              colors: {
+                primary: '#654321',
+                colorKey: 'blue',
+                customVar: 'var(--fd-color-dark)',
+              },
+            },
+          },
+        }),
+      ],
+    })
+
+    const targets = ['text-color-key', 'text-custom-var']
+    const { css } = await uno.generate(targets.join('\n'))
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: preflights */
+      *,::before,::after{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-pan-x: ;--un-pan-y: ;--un-pinch-zoom: ;--un-scroll-snap-strictness:proximity;--un-ordinal: ;--un-slashed-zero: ;--un-numeric-figure: ;--un-numeric-spacing: ;--un-numeric-fraction: ;--un-border-spacing-x:0;--un-border-spacing-y:0;--un-ring-offset-shadow:0 0 rgba(0,0,0,0);--un-ring-shadow:0 0 rgba(0,0,0,0);--un-shadow-inset: ;--un-shadow:0 0 rgba(0,0,0,0);--un-ring-inset: ;--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-width:0px;--un-ring-color:rgba(147,197,253,0.5);--un-blur: ;--un-brightness: ;--un-contrast: ;--un-drop-shadow: ;--un-grayscale: ;--un-hue-rotate: ;--un-invert: ;--un-saturate: ;--un-sepia: ;--un-backdrop-blur: ;--un-backdrop-brightness: ;--un-backdrop-contrast: ;--un-backdrop-grayscale: ;--un-backdrop-hue-rotate: ;--un-backdrop-invert: ;--un-backdrop-opacity: ;--un-backdrop-saturate: ;--un-backdrop-sepia: ;}::backdrop{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-pan-x: ;--un-pan-y: ;--un-pinch-zoom: ;--un-scroll-snap-strictness:proximity;--un-ordinal: ;--un-slashed-zero: ;--un-numeric-figure: ;--un-numeric-spacing: ;--un-numeric-fraction: ;--un-border-spacing-x:0;--un-border-spacing-y:0;--un-ring-offset-shadow:0 0 rgba(0,0,0,0);--un-ring-shadow:0 0 rgba(0,0,0,0);--un-shadow-inset: ;--un-shadow:0 0 rgba(0,0,0,0);--un-ring-inset: ;--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-width:0px;--un-ring-color:rgba(147,197,253,0.5);--un-blur: ;--un-brightness: ;--un-contrast: ;--un-drop-shadow: ;--un-grayscale: ;--un-hue-rotate: ;--un-invert: ;--un-saturate: ;--un-sepia: ;--un-backdrop-blur: ;--un-backdrop-brightness: ;--un-backdrop-contrast: ;--un-backdrop-grayscale: ;--un-backdrop-hue-rotate: ;--un-backdrop-invert: ;--un-backdrop-opacity: ;--un-backdrop-saturate: ;--un-backdrop-sepia: ;}
+      /* layer: theme */
+      .dark{--un-preset-theme-colors-colorKey:blue;--un-preset-theme-colors-customVar:var(--fd-color-dark);}
+      :root{--un-preset-theme-colors-colorKey:red;--un-preset-theme-colors-customVar:var(--fd-color-light);}
+      /* layer: default */
+      .text-color-key{color:var(--un-preset-theme-colors-colorKey);}
+      .text-custom-var{color:var(--un-preset-theme-colors-customVar);}"
+    `)
+  })
 })


### PR DESCRIPTION
This pr add surpport for `keyword color` (like "red" "blue" etc.) and `custom vars` from other css file. 

**:warning:**: with [move :root first PR](https://github.com/Dunqing/unocss-preset-theme/pull/48#issuecomment-1658288231), we move `:root` element to first. if this pr merge after that, plz pay attention to the last test case.

Sometimes, maybe someone needed, just like case:
case for keyword color:
* Due to test the preset, someone maybe use keyword color for convenient. if the preset doesn't work, it will confused.

case for custom vars:
* When we have animation color css, we want change animation color with theme change, we need bound custom vars with theme's vars.

The two case please check in unocss playground link:
 https://uno.antfu.me/play/?html=DwCwjABAxgNghgZwQXgEQBcCmAPdBaKAexkICcBpTAT1QD4AVTBdCAa2oHcyATaYsiAAEIMAJYBzEOgD0pQoRboQmALaZg08LQBQoSLEQoMOfERIVqEbnFKs6jZm048%2B5oVZusIS1es1gdXXBoeCQ0LFwCAFdmQhU8ADcbOgAZCSloGPQ4iCTSBA0tIP1QowjTLLjEmw9bVPSWKEqVXJsC-x0gA&config=PTAEFcDsHsDoGNqQGYEsDmsAuBnAUKgLYAO0ATlqAN6gAmApmpPQMJJroA0oxZ9O9LAFUYoAL6hkZaIVAByKNHg4ccgiXKVe-QQBUAFvUL1J02QpjKcAWm0Cs1rIeNq89AB6kKdRgENwADaUDEys7BgAFFR4oKBORvQAXNQxsaCIAeQ4ydFpaRnkANL0AJ7Jcny0cpypefDgOFgyAGq%2BZOUAbm0R1tbItNYFZNYBGPpYAJRqeWI1sbOpdoLZoADatTx89iLQERNzaSAAArjWGDB8G0tYBglRG7HxxjkPh2BsKBjgfHRtANZxZz8V6xWj-F55SHpaCZMgrXJQyFDYpleQAIwC4Ho1RBSIaTUIrXa8i6ZB6fQGQ2sYLIfymuPmDNAuIWUNZaTE%2B1SAF0apy8EA&css=AIawpgngZgTghgWzAZwATwJYDsBGB7Ad1QG8AoVVABgFITUBaeqAE3oGM8AbPGezjAOYALAC4AuVAGJKlOAE4AHGADcDJqw7dezODBATplOVCgB2VQF9yARgCstYmpbsuPPoNEGZcACxhzThqu2rr6UsambGByluQAzDR0jM6abvzC4lIAbHEKcFAKqslBWvQ6egZgULZycgBMsag%2B9knqLqXpnlJg1lmUOHFFbakhFVLMOKZxcVmNfQ6B7WkemZJgOFm2tg2LI2WhBgo4cqZ2jaYtjsVLvJ2rcDgKzJRsQynB%2B2OGcKZZr6hWVByRJXYYfO4GOI%2BXw%2BHBvEpucphb4KNhQWLWGQLa57CFSbyKFS7D5IrxGEwBKxWUhiGB4PAiEjkYkdFZk%2BRKeE3T7ImTGMzKZlwLAYBBwEQYPBYCSYXCEVCYtD8LBgXSobBQbAYEQqUgWIA&options=N4XyA


